### PR TITLE
fix bug where request.user was renamed to request.user_type

### DIFF
--- a/friendo_site/friendo_site/users/views.py
+++ b/friendo_site/friendo_site/users/views.py
@@ -28,7 +28,7 @@ def discord_login_redirect(request: HttpRequest):
     user_data = exchange_code(code)
 
     try:
-        user = request.user_type
+        user = request.user
         user.discord_id = int(user_data.get("id"))
         user.discord_username = user_data.get("username")
         user.discord_discriminator = user_data.get("discriminator")
@@ -88,7 +88,7 @@ def exchange_code(code: str) -> dict:
 
 
 def register(request):
-    if not request.user_type.is_authenticated:
+    if not request.user.is_authenticated:
         if request.method == "POST":
             form = UserRegisterForm(request.POST)
 
@@ -105,7 +105,7 @@ def register(request):
 
 
 def login_view(request):
-    if not request.user_type.is_authenticated:
+    if not request.user.is_authenticated:
         username = request.POST.get("username", None)
         password = request.POST.get("password", None)
         user = authenticate(request, username=username, password=password)
@@ -123,7 +123,7 @@ def profile(request):
 
 
 def logout_view(request):
-    if request.user_type.is_authenticated:
+    if request.user.is_authenticated:
         logout(request)
         messages.success(request, "You have been logged out.")
     return redirect("index")


### PR DESCRIPTION
Some buffoon did a search and replace to rename a variable used for graphql from  to  but accidentally renamed it on the entire project's scope. I have renamed the variable back in the user views so that users authentication works again. I am the true hero. On new year's eve nonetheless