### PR TITLE
add blog link to abandon tech

### DIFF
--- a/friendo_site/friendo_site/templates/index.html
+++ b/friendo_site/friendo_site/templates/index.html
@@ -27,5 +27,11 @@
             </div>
         </div>
 
+        <div class="row justify-content-center">
+            <div class="column">
+                <a href="https://blog.abandontech.cloud/" target="_blank" type="button" class="btn btn-lg btn-outline-light" style="width: 100px; margin-top: 50px">Blog</a>
+            </div>
+        </div>
+
     </div>
 {% endblock content %}


### PR DESCRIPTION
Abandon tech blog will likely host guides related to discord bot developement and backends related to the methods used to friendo. I am linking the blog here to allow for more, relevant traffic to the AT blog.